### PR TITLE
Fix libnx 1.4 compile error:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ CFLAGS	:=	-g -Wall -O2 -fpermissive -ffunction-sections \
 
 CFLAGS	+=	$(INCLUDE) -D__SWITCH__
 
-CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=c++11
+CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=c++14
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)


### PR DESCRIPTION
/opt/devkitpro/libnx/include/switch/services/audren.h:305:1: error: body of 'constexpr' function 'constexpr size_t audrenGetInputParamSize(const AudioRendererConfig*)' not a return-statement

for libnx 1.4 we need c++ 14